### PR TITLE
failing test for image.verify()

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -137,3 +137,8 @@ def test_not_load_truncated():
 def test_load_truncated():
     image = Image.open(respath('test-crop.heic'))
     image.load()
+
+
+def test_verify():
+    image = Image.open(respath('test-crop.heic'))
+    image.verify()


### PR DESCRIPTION
## Description

Opening a heif image and calling `.verify()` throws exception.

```
        if self._exclusive_fp:
>           self.fp.close()
E           AttributeError: 'NoneType' object has no attribute 'close'
```

This is used for django to validate images. It seems to be a perfectly valid way to use PIL api.

https://github.com/django/django/blob/21d8ea4eb3e22d458515b5278c8cd3a15b069799/django/forms/fields.py#L714-L716


This PR only contains a test which currently fails to reproduce the test.

I'm not sure about the best way to fix this issue.  Imho it is caused by the following code in the `_open` method:

```
        if self._exclusive_fp:
            self.fp.close()
        self.fp = None
```

imho this should only be done in `load` and `verify`? 

a workaround fix would obviously to simply overwrite `verify` to be a no-op.. 
