### PR TITLE
fix extras_require syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     extras_require={
         'test': [
-            'pillow>=6.0.0'
+            'pillow>=6.0.0',
             'pytest>=4.6.5',
             'pytest-cov>=2.8.1',
         ]


### PR DESCRIPTION
the setup.py misses a `,` so I get the following warning:

```
Invalid constraint (pillow>=6.0.0pytest>=4.6.5 ; extra == "test") found in heif-image-plugin-0.4.0
```
